### PR TITLE
Optimize performance and jar size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,27 @@ version = '1.1.0'
 def junitTestVersion = '5.8.2'
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
     withSourcesJar()
     withJavadocJar()
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.debug = false // reduce classfile size
+}
+
+tasks.withType(Jar).configureEach {
+    // Reproducible jars: stable ordering and timestamps
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+    // Minimal manifest
+    manifest.attributes(
+            'Implementation-Title': 'swedish-holidays',
+            'Implementation-Version': project.version
+    )
 }
 
 repositories {
@@ -26,13 +42,16 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params:' + junitTestVersion
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:' + junitTestVersion
 
-    /// JMH dependencies (use latest versions)
+    /// JMH dependencies (avoid on main classpath)
     testImplementation 'org.openjdk.jmh:jmh-core:1.37'
     testAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
 }
 
 test {
     useJUnitPlatform()
+    jvmArgs = [
+            '-XX:+UseStringDeduplication'
+    ]
 }
 
 // JReleaser configuration for signing & deployment


### PR DESCRIPTION
Optimize holiday calculation performance, reduce jar size, and improve load times.

Removed eager cache pre-population, added per-year Easter date caching, replaced stream operations with imperative loops, and switched to `AtomicReferenceArray` for language-specific caches to reduce allocations and speed up calculations. Jar size was reduced by disabling debug info and enabling reproducible builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a4aeeb6-4f9f-4d52-a959-c0ebfa242be6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a4aeeb6-4f9f-4d52-a959-c0ebfa242be6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

